### PR TITLE
[aiji42] fix: realtime cursor

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,5 @@ module.exports = {
   reactStrictMode: true,
   env: {
     ABLY_IS_ACTIVE: !!process.env.ABLY_API_KEY,
-    ABLY_API_ENDPOINT: process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}/api/ably-create-token`
-      : `http://localhost:3000/api/ably-create-token`,
   },
 };

--- a/src/libs/realtime-cursor/use-realtime-cursor.ts
+++ b/src/libs/realtime-cursor/use-realtime-cursor.ts
@@ -12,7 +12,7 @@ import useMouse from "@react-hook/mouse-position";
 
 const ably = process.env.ABLY_IS_ACTIVE
   ? new Realtime.Promise({
-      authUrl: process.env.ABLY_API_ENDPOINT,
+      authUrl: "/api/ably-create-token",
     })
   : null;
 


### PR DESCRIPTION
ablyのトークンを発行するためのエンドポイントが、CORSポリシによってブロックされてしまう問題の対処。